### PR TITLE
feat: rename module to navacloud and emit dual correlation headers

### DIFF
--- a/.traefik.yml
+++ b/.traefik.yml
@@ -1,9 +1,10 @@
 displayName: Correlation ID
 type: middleware
 
-import: github.com/kluisz/traefik-correlation-id-plugin
+import: github.com/navacloud/traefik-correlation-id-plugin
 
 summary: 'This plugin adds a uuid7 correleation ID to the request headers'
 
 testData:
-  headerName: "X-Klz-Correlation-Id"
+  headerName: "X-Nava-Correlation-Id"
+  legacyHeaderName: "X-Klz-Correlation-Id"

--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 # Traefik Correlation ID Plugin
 
-A Traefik middleware plugin that automatically generates and propagates correlation IDs across requests using UUID v7.
+A Traefik middleware plugin that automatically generates and propagates correlation IDs across requests using UUID v7. Supports dual-header emission for backward compatibility during a header rename.
 
 ## Features
 
 - **Automatic UUID v7 Generation** — Generates a unique correlation ID for each request if one doesn't already exist
 - **Header Pass-through** — Preserves existing correlation IDs from upstream services
-- **Configurable Header Name** — Customize the header name (defaults to `X-Klz-Correlation-Id`)
-- **Zero Dependencies** — Uses only the standard library and Google's UUID library
+- **Dual-Header Backward Compatibility** — Reads either of two configured header names (preferring `headerName`, falling back to `legacyHeaderName`) and writes the resolved value to both on the outgoing request
+- **Configurable Header Names** — Override either or both header names; set `legacyHeaderName: ""` to disable dual-write
+- **Zero Dependencies** — Uses only the standard library
 
 ## Installation
 
@@ -21,7 +22,8 @@ http:
     correlation-id:
       plugin:
         correlation-id:
-          headerName: X-Klz-Correlation-Id  # Optional, defaults to X-Klz-Correlation-Id
+          headerName: X-Nava-Correlation-Id        # Optional, defaults to X-Nava-Correlation-Id
+          legacyHeaderName: X-Klz-Correlation-Id   # Optional, defaults to X-Klz-Correlation-Id; set "" to disable
 ```
 
 ## Usage
@@ -40,9 +42,14 @@ http:
 
 ## How It Works
 
-1. If the request already has a correlation ID header, it is preserved and passed downstream
-2. If no correlation ID exists, a new UUID v7 is generated and added to the request
-3. The middleware passes the request (with the correlation ID) to the next handler
+1. The plugin looks for the correlation ID on the inbound request, preferring `headerName` and falling back to `legacyHeaderName`
+2. If neither header is present, a new ID is generated from 16 cryptographically random bytes (hex-encoded)
+3. The resolved ID is written to both `headerName` and `legacyHeaderName` on the outgoing request, so downstream services that have not yet migrated can still read the legacy header
+4. The middleware passes the request to the next handler
+
+## Migration Notes
+
+The defaults reflect the post-rebrand state: `X-Nava-Correlation-Id` is canonical, `X-Klz-Correlation-Id` is the legacy compatibility header. Once all downstream services read the new header, set `legacyHeaderName: ""` to stop emitting the legacy one.
 
 ## UUID v7 Format
 

--- a/correlation.go
+++ b/correlation.go
@@ -10,42 +10,76 @@ import (
 	"net/http"
 )
 
+// Default header names. The primary header is the canonical post-rebrand name;
+// the legacy header is preserved so downstream services not yet migrated still
+// see a correlation ID. Both headers are always written with the same value.
+const (
+	defaultHeaderName       = "X-Nava-Correlation-Id"
+	defaultLegacyHeaderName = "X-Klz-Correlation-Id"
+)
+
 // Config the plugin configuration.
+//
+// Backwards-compatibility model: incoming requests may carry the correlation
+// ID under either HeaderName or LegacyHeaderName. The plugin reads from the
+// primary first, falls back to legacy, and always writes the resolved value
+// to BOTH headers on the outgoing request. Set LegacyHeaderName to the empty
+// string to disable dual-write once all downstream consumers have migrated.
 type Config struct {
-	HeaderName string `yaml:"headerName,omitempty" json:"header_name,omitempty"`
+	HeaderName       string `yaml:"headerName,omitempty" json:"header_name,omitempty"`
+	LegacyHeaderName string `yaml:"legacyHeaderName,omitempty" json:"legacy_header_name,omitempty"`
 }
 
 // CreateConfig creates the default plugin configuration.
 func CreateConfig() *Config {
 	return &Config{
-		HeaderName: "",
+		HeaderName:       "",
+		LegacyHeaderName: "",
 	}
 }
 
 type Correlation struct {
-	next       http.Handler
-	name       string
-	headerName string
+	next             http.Handler
+	name             string
+	headerName       string
+	legacyHeaderName string
 }
 
 // New created a new plugin.
 func New(_ context.Context, next http.Handler, config *Config, name string) (http.Handler, error) {
 	if config.HeaderName == "" {
-		config.HeaderName = "X-Klz-Correlation-Id"
+		config.HeaderName = defaultHeaderName
+	}
+	if config.LegacyHeaderName == "" {
+		config.LegacyHeaderName = defaultLegacyHeaderName
 	}
 
 	return &Correlation{
-		next:       next,
-		name:       name,
-		headerName: config.HeaderName,
+		next:             next,
+		name:             name,
+		headerName:       config.HeaderName,
+		legacyHeaderName: config.LegacyHeaderName,
 	}, nil
 }
 
 func (c *Correlation) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
-	if request.Header.Get(c.headerName) == "" {
+	// Resolve the correlation ID: prefer the primary header, fall back to the
+	// legacy header, generate if neither is set.
+	id := request.Header.Get(c.headerName)
+	if id == "" && c.legacyHeaderName != "" {
+		id = request.Header.Get(c.legacyHeaderName)
+	}
+	if id == "" {
 		b := make([]byte, 16)
 		if _, err := rand.Read(b); err == nil {
-			request.Header.Set(c.headerName, hex.EncodeToString(b))
+			id = hex.EncodeToString(b)
+		}
+	}
+
+	if id != "" {
+		request.Header.Set(c.headerName, id)
+		if c.legacyHeaderName != "" {
+			request.Header.Set(c.legacyHeaderName, id)
 		}
 	}
 

--- a/correlation_test.go
+++ b/correlation_test.go
@@ -9,94 +9,124 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	traefik_correlation_id_plugin "github.com/kluisz/traefik-correlation-id-plugin"
+	traefik_correlation_id_plugin "github.com/navacloud/traefik-correlation-id-plugin"
 )
 
-func TestCorrelation_GeneratesID(t *testing.T) {
-	cfg := traefik_correlation_id_plugin.CreateConfig()
+const (
+	primaryHeader = "X-Nava-Correlation-Id"
+	legacyHeader  = "X-Klz-Correlation-Id"
+)
 
-	ctx := context.Background()
+func newHandler(t *testing.T, cfg *traefik_correlation_id_plugin.Config) http.Handler {
+	t.Helper()
 	next := http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {})
-
-	handler, err := traefik_correlation_id_plugin.New(ctx, next, cfg, "correlation-plugin")
+	handler, err := traefik_correlation_id_plugin.New(context.Background(), next, cfg, "correlation-plugin")
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	recorder := httptest.NewRecorder()
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://localhost", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	handler.ServeHTTP(recorder, req)
-
-	assertHeaderNotEmpty(t, req, "X-Klz-Correlation-Id")
+	return handler
 }
 
-func TestCorrelation_PreservesExistingID(t *testing.T) {
-	cfg := traefik_correlation_id_plugin.CreateConfig()
-
-	ctx := context.Background()
-	next := http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {})
-
-	handler, err := traefik_correlation_id_plugin.New(ctx, next, cfg, "correlation-plugin")
+func newRequest(t *testing.T) *http.Request {
+	t.Helper()
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://localhost", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	recorder := httptest.NewRecorder()
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://localhost", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	existing := "my-existing-correlation-id"
-	req.Header.Set("X-Klz-Correlation-Id", existing)
-
-	handler.ServeHTTP(recorder, req)
-
-	assertHeader(t, req, "X-Klz-Correlation-Id", existing)
+	return req
 }
 
-func TestCorrelation_CustomHeaderName(t *testing.T) {
+// TestCorrelation_GeneratesAndDualWrites confirms that when neither header is
+// set on the inbound request the plugin generates an ID and writes it to BOTH
+// the primary and legacy headers with identical values.
+func TestCorrelation_GeneratesAndDualWrites(t *testing.T) {
+	handler := newHandler(t, traefik_correlation_id_plugin.CreateConfig())
+	req := newRequest(t)
+
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+
+	primary := req.Header.Get(primaryHeader)
+	legacy := req.Header.Get(legacyHeader)
+	if primary == "" {
+		t.Errorf("expected primary header %q to be set", primaryHeader)
+	}
+	if legacy == "" {
+		t.Errorf("expected legacy header %q to be set", legacyHeader)
+	}
+	if primary != legacy {
+		t.Errorf("primary and legacy must match: %q vs %q", primary, legacy)
+	}
+}
+
+// TestCorrelation_PreservesPrimary confirms an inbound primary header is kept
+// and propagated to the legacy header for downstream compatibility.
+func TestCorrelation_PreservesPrimary(t *testing.T) {
+	handler := newHandler(t, traefik_correlation_id_plugin.CreateConfig())
+	req := newRequest(t)
+	const existing = "primary-id"
+	req.Header.Set(primaryHeader, existing)
+
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+
+	if got := req.Header.Get(primaryHeader); got != existing {
+		t.Errorf("primary = %q, want %q", got, existing)
+	}
+	if got := req.Header.Get(legacyHeader); got != existing {
+		t.Errorf("legacy = %q, want %q", got, existing)
+	}
+}
+
+// TestCorrelation_PromotesLegacy confirms a legacy-only inbound header is
+// adopted and mirrored to the primary header (reverse migration support).
+func TestCorrelation_PromotesLegacy(t *testing.T) {
+	handler := newHandler(t, traefik_correlation_id_plugin.CreateConfig())
+	req := newRequest(t)
+	const existing = "legacy-id"
+	req.Header.Set(legacyHeader, existing)
+
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+
+	if got := req.Header.Get(primaryHeader); got != existing {
+		t.Errorf("primary = %q, want %q", got, existing)
+	}
+	if got := req.Header.Get(legacyHeader); got != existing {
+		t.Errorf("legacy = %q, want %q", got, existing)
+	}
+}
+
+// TestCorrelation_PrimaryWinsOnCollision confirms that when both headers are
+// inbound with different values the primary takes precedence and overwrites
+// the legacy on the outgoing request.
+func TestCorrelation_PrimaryWinsOnCollision(t *testing.T) {
+	handler := newHandler(t, traefik_correlation_id_plugin.CreateConfig())
+	req := newRequest(t)
+	req.Header.Set(primaryHeader, "primary-wins")
+	req.Header.Set(legacyHeader, "legacy-loses")
+
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+
+	if got := req.Header.Get(primaryHeader); got != "primary-wins" {
+		t.Errorf("primary = %q, want primary-wins", got)
+	}
+	if got := req.Header.Get(legacyHeader); got != "primary-wins" {
+		t.Errorf("legacy = %q, want primary-wins (overwritten)", got)
+	}
+}
+
+// TestCorrelation_CustomHeaderNames confirms operators can override both names.
+func TestCorrelation_CustomHeaderNames(t *testing.T) {
 	cfg := traefik_correlation_id_plugin.CreateConfig()
 	cfg.HeaderName = "X-Request-Id"
+	cfg.LegacyHeaderName = "X-Old-Request-Id"
 
-	ctx := context.Background()
-	next := http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {})
+	handler := newHandler(t, cfg)
+	req := newRequest(t)
 
-	handler, err := traefik_correlation_id_plugin.New(ctx, next, cfg, "correlation-plugin")
-	if err != nil {
-		t.Fatal(err)
-	}
+	handler.ServeHTTP(httptest.NewRecorder(), req)
 
-	recorder := httptest.NewRecorder()
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://localhost", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	handler.ServeHTTP(recorder, req)
-
-	assertHeaderNotEmpty(t, req, "X-Request-Id")
-}
-
-func assertHeader(t *testing.T, req *http.Request, key, expected string) {
-	t.Helper()
-
-	if req.Header.Get(key) != expected {
-		t.Errorf("invalid header value for %s: got %q, want %q", key, req.Header.Get(key), expected)
-	}
-}
-
-func assertHeaderNotEmpty(t *testing.T, req *http.Request, key string) {
-	t.Helper()
-
-	if req.Header.Get(key) == "" {
-		t.Errorf("expected header %s to be set, but it was empty", key)
+	primary := req.Header.Get("X-Request-Id")
+	legacy := req.Header.Get("X-Old-Request-Id")
+	if primary == "" || legacy == "" || primary != legacy {
+		t.Errorf("expected matching non-empty headers, got primary=%q legacy=%q", primary, legacy)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/kluisz/traefik-correlation-id-plugin
+module github.com/navacloud/traefik-correlation-id-plugin
 
 go 1.21


### PR DESCRIPTION
Rename the Go module path from `github.com/kluisz/...` to `github.com/navacloud/traefik-correlation-id-plugin` and extend the plugin to read either `X-Nava-Correlation-Id` or `X-Klz-Correlation-Id` on input and always write both on output, so requests stay correlated across services that have not yet migrated.

BREAKING CHANGE: module path changed; consumers must update imports and `Traefik` experimental plugin moduleName.

Refs navacloud/helm-charts#390